### PR TITLE
Remove 'modern' from url endpoints

### DIFF
--- a/garpy/resources/default_config.yaml
+++ b/garpy/resources/default_config.yaml
@@ -1,38 +1,38 @@
 backup-dir: 'activities'
 endpoints:
   SSO_LOGIN_URL: "https://sso.garmin.com/sso/signin"
-  ACTIVITY_LIST: "https://connect.garmin.com/modern/proxy/activitylist-service/activities/search/activities"
+  ACTIVITY_LIST: "https://connect.garmin.com/proxy/activitylist-service/activities/search/activities"
 activities:
   summary:
-    endpoint: "https://connect.garmin.com/modern/proxy/activity-service/activity/{id}"
+    endpoint: "https://connect.garmin.com/proxy/activity-service/activity/{id}"
     suffix: "_summary.json"
   details:
-    endpoint: "https://connect.garmin.com/modern/proxy/activity-service/activity/{id}/details"
+    endpoint: "https://connect.garmin.com/proxy/activity-service/activity/{id}/details"
     suffix: "_details.json"
   gpx:
-    endpoint: "https://connect.garmin.com/modern/proxy/download-service/export/gpx/activity/{id}"
+    endpoint: "https://connect.garmin.com/proxy/download-service/export/gpx/activity/{id}"
     suffix: ".gpx"
     tolerate:
       - 404
       - 204
   tcx:
-    endpoint: "https://connect.garmin.com/modern/proxy/download-service/export/tcx/activity/{id}"
+    endpoint: "https://connect.garmin.com/proxy/download-service/export/tcx/activity/{id}"
     suffix: ".tcx"
     tolerate:
       - 404
   original:
-    endpoint: "https://connect.garmin.com/modern/proxy/download-service/files/activity/{id}"
+    endpoint: "https://connect.garmin.com/proxy/download-service/files/activity/{id}"
     suffix: ".fit"
     tolerate:
       - 404
       - 500
   mkl:
-    endpoint: "https://connect.garmin.com/modern/proxy/download-service/export/kml/activity/{id}"
+    endpoint: "https://connect.garmin.com/proxy/download-service/export/kml/activity/{id}"
     suffix: ".mkl"
     tolerate:
       - 404
       - 204
 wellness:
-  endpoint: "https://connect.garmin.com/modern/proxy/download-service/files/wellness/{date}"
+  endpoint: "https://connect.garmin.com/proxy/download-service/files/wellness/{date}"
   tolerate:
     - 404


### PR DESCRIPTION
This fixes #10. The garmin endpoints have changed and dropped the "modern" prefix.
