### PR TITLE
Add support for windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ python:
 
 jobs:
   include:
-    - name: "Python 3.8.0 on macOS 10.14"
+    - name: "Python 3.7.7 on macOS 10.14"
       os: osx
-      osx_image: xcode11.3  # Python 3.8.0 running on macOS 10.14.6
+      osx_image: xcode11.3  # Python 3.7.7 running on macOS 10.14.6
       language: shell       # 'language: python' is an error on Travis CI macOS
     - name: "Python 3.8.8 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: xenial
 
 language: python
@@ -10,11 +11,28 @@ python:
   - "3.8"
   - "3.9"
 
+jobs:
+  include:
+    - name: "Python 3.8.0 on macOS 10.14"
+      os: osx
+      osx_image: xcode11.3  # Python 3.8.0 running on macOS 10.14.6
+      language: shell       # 'language: python' is an error on Travis CI macOS
+    - name: "Python 3.8.8 on Windows"
+      os: windows           # Windows 10.0.17134 N/A Build 17134
+      language: shell       # 'language: python' is an error on Travis CI Windows
+      before_install:
+        - choco install python --version 3.8.8
+        - python --version
+        - python -m pip install --upgrade pip
+        - python -m pip install poetry
+      env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
 before_install:
-- pip install poetry
+- python3 --version
+- python3 -m pip install --upgrade pip
+- python3 -m pip install --upgrade poetry
 install:
 - poetry install
 script:
 - poetry run pytest --cov-report term-missing --cov=garpy tests/
 after_success:
-- coveralls
+- python3 -m coveralls

--- a/garpy/activity.py
+++ b/garpy/activity.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import json
+import os
 import zipfile
 from io import BytesIO
 from pathlib import Path
@@ -44,7 +45,10 @@ class Activity:
 
     @property
     def base_filename(self):
-        return f"{self.start.in_tz('UTC').isoformat()}_{self.id}"
+        filename = f"{self.start.in_tz('UTC').isoformat()}_{self.id}"
+        if os.name == "nt": # Windows complains about : in filenames.
+            filename = filename.replace(':', '.')
+        return filename
 
     def get_export_filepath(self, backup_dir: Path, fmt: str) -> Path:
         format_parameters = config["activities"].get(fmt)

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import json
+import os
 import zipfile
 from pathlib import Path
 from unittest.mock import Mock
@@ -52,6 +53,8 @@ class TestActivity:
 
     def test_filepath_awareness(self, activity, tmp_path):
         expected_base_filename = "2018-11-24T09:30:00+00:00_2532452238"
+        if os.name == "nt":
+            expected_base_filename = expected_base_filename.replace(':', '.')
         assert activity.base_filename == expected_base_filename
         assert activity.get_export_filepath(tmp_path, "gpx") == tmp_path / (
             expected_base_filename + ".gpx"


### PR DESCRIPTION
Windows complains about colons on the filenames. For Windows users garpy will now use dots instead of colons to separate hours, minutes and seconds on the filenames, e,g,:

`2021-04-28T12:52:38+00:00_6687511285.fit`

becomes

`2021-04-28T12.52.38+00.00_6687511285.fit`

I didn't change the behavior in Linux to maintain backwards compatibility with linux users that already have backed up activities

I also added Windows and Mac OSX jobs to Travis so that I can track compatibility in the future.

This fixes issue #12 