### PR TITLE
Revert "Update click requirement from ^7.0 to >=7,<9"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requests = "^2.22"
 attrs = "^19.1"
 pendulum = "^2.0"
 PyYAML = "^5.1"
-click = ">=7,<9"
+click = "^7.0"
 tqdm = "^4.36"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requests = "^2.22"
 attrs = "^19.1"
 pendulum = "^2.0"
 PyYAML = "^5.1"
-click = "^7.0"
+click = ">=7,<8"
 tqdm = "^4.36"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Reverts felipeam86/garpy#16

Travis failed for Python 3.6. I don't want to drop 3.6 support yet just to update click